### PR TITLE
fix a function call error

### DIFF
--- a/donation-rs/integration-tests/rs/src/tests.rs
+++ b/donation-rs/integration-tests/rs/src/tests.rs
@@ -12,7 +12,7 @@ async fn main() -> anyhow::Result<()> {
     let contract = worker.dev_deploy(&wasm).await?;
 
     // create accounts
-    let owner = worker.root_account();
+    let owner = worker.root_account()?;
 
     let alice = owner
         .create_subaccount(&worker, "alice")


### PR DESCRIPTION
owner is a type of Result<Account, Error> without ? at the end of `root_account()` call